### PR TITLE
Extensibility

### DIFF
--- a/website/frontend/management/commands/_monkeypatches.py
+++ b/website/frontend/management/commands/_monkeypatches.py
@@ -1,0 +1,56 @@
+# subprocess.check_output appeared in python 2.7.
+# Linerva only has 2.6
+import subprocess
+def check_output(*popenargs, **kwargs):
+    r"""Run command with arguments and return its output as a byte string.
+
+    If the exit code was non-zero it raises a CalledProcessError.  The
+    CalledProcessError object will have the return code in the returncode
+    attribute and output in the output attribute.
+
+    The arguments are the same as for the Popen constructor.  Example:
+
+    >>> check_output(["ls", "-l", "/dev/null"])
+    'crw-rw-rw- 1 root root 1, 3 Oct 18  2007 /dev/null\n'
+
+    The stdout argument is not allowed as it is used internally.
+    To capture standard error in the result, use stderr=STDOUT.
+
+    >>> check_output(["/bin/sh", "-c",
+    ...               "ls -l non_existent_file ; exit 0"],
+    ...              stderr=STDOUT)
+    'ls: non_existent_file: No such file or directory\n'
+    """
+    from subprocess import PIPE, CalledProcessError, Popen
+    if 'stdout' in kwargs:
+        raise ValueError('stdout argument not allowed, it will be overridden.')
+    process = Popen(stdout=PIPE, *popenargs, **kwargs)
+    output, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        raise CalledProcessError(retcode, cmd, output=output)
+    return output
+    
+if not hasattr(subprocess, 'check_output'):
+    subprocess.check_output = check_output
+
+# Begin hot patch for https://bugs.launchpad.net/bugs/788986
+# Ick.
+import sys
+from BeautifulSoup import BeautifulSoup
+def bs_fixed_getText(self, separator=u""):
+    bsmod = sys.modules[BeautifulSoup.__module__]
+    if not len(self.contents):
+        return u""
+    stopNode = self._lastRecursiveChild().next
+    strings = []
+    current = self.contents[0]
+    while current is not stopNode:
+        if isinstance(current, bsmod.NavigableString):
+            strings.append(current)
+        current = current.next
+    return separator.join(strings)
+sys.modules[BeautifulSoup.__module__].Tag.getText = bs_fixed_getText

--- a/website/frontend/management/commands/_utils.py
+++ b/website/frontend/management/commands/_utils.py
@@ -1,7 +1,7 @@
 GIT_PROGRAM = 'git'
 
-import os, errno
 def mkdir_p(path):
+    import os, errno
     try:
         os.makedirs(path)
     except OSError as exc: # Python >2.5
@@ -21,8 +21,8 @@ def strip_prefix(string, prefix):
 def url_to_filename(url):
     return strip_prefix(url, 'http://').rstrip('/')
 
-import cookielib, urllib2, socket, time
 def grab_url(url, max_depth=5, opener=None):
+    import cookielib, urllib2, socket, time
     if opener is None:
         cj = cookielib.CookieJar()
         opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))

--- a/website/frontend/management/commands/_utils.py
+++ b/website/frontend/management/commands/_utils.py
@@ -1,0 +1,45 @@
+GIT_PROGRAM = 'git'
+
+import os, errno
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc: # Python >2.5
+        if exc.errno == errno.EEXIST:
+            pass
+        else:
+            raise
+
+def canonicalize_url(url):
+    return url.split('?')[0].split('#')[0].strip()
+
+def strip_prefix(string, prefix):
+    if string.startswith(prefix):
+        string = string[len(prefix):]
+    return string
+
+def url_to_filename(url):
+    return strip_prefix(url, 'http://').rstrip('/')
+
+import cookielib, urllib2, socket, time
+def grab_url(url, max_depth=5, opener=None):
+    if opener is None:
+        cj = cookielib.CookieJar()
+        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
+    retry = False
+    try:
+        text = opener.open(url, timeout=5).read()
+        if '<title>NY Times Advertisement</title>' in text:
+            retry = True
+    except socket.timeout:
+        retry = True
+    if retry:
+        if max_depth == 0:
+            raise Exception('Too many attempts to download %s' % url)
+        time.sleep(0.5)
+        return grab_url(url, max_depth-1, opener)
+    return text
+
+def strip_whitespace(text):
+    lines = text.split('\n')
+    return '\n'.join(x.strip().rstrip(u'\xa0') for x in lines).strip() + '\n'

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -113,35 +113,6 @@ def migrate_versions():
             pass
 
 '''
-class PoliticoArticle(Article):
-    SUFFIX = ''
-
-    def _parse(self, html):
-        soup = bs4.BeautifulSoup(html)
-        print_link = soup.findAll('a', text='Print')[0].get('href')
-        html2 = grab_url(print_link)
-        # Now we have to switch back to bs3.  Hilarious.
-        # and the labeled encoding is wrong, so force utf-8.
-        soup = BeautifulSoup(html2, convertEntities=BeautifulSoup.HTML_ENTITIES,
-                             fromEncoding='utf-8')
-
-        self.meta = soup.findAll('meta')
-        p_tags = soup.findAll('p')[1:]
-
-        self.title = soup.find('strong').getText()
-        entity = soup.find('span', attrs={'class':'author'})
-        children = list(entity.childGenerator())
-        self.byline = 'By ' + children[1].getText()
-        datestr = children[-1].strip()
-        self.date = datestr
-
-        self.body = '\n'+'\n\n'.join([p.getText() for p in p_tags])
-
-    def __unicode__(self):
-        return strip_whitespace(u'\n'.join((self.date, self.title, self.byline,
-                                            self.body,)))
-
-
 class BBCArticle(Article):
     SUFFIX = '?print=true'
 
@@ -245,9 +216,6 @@ class TagesschauArticle(Article):
 '''
 
 #feeders = [
-#           ('http://www.politico.com/',
-#            lambda url: 'www.politico.com/news/stories' in url,
-#            bs4.BeautifulSoup),
 #           ('http://www.bbc.co.uk/news/',
 #            lambda url: 'www.bbc.co.uk/news' in url),
 #           ]
@@ -265,7 +233,7 @@ class TagesschauArticle(Article):
 domain_to_class = {}
 url_fetchers = []
 # checked with 'in scraper.fetcher_url', simple and stupid
-urls_to_fetch = ['cnn', 'nyt'] 
+urls_to_fetch = 'cnn nyt politico'.split(' ')
 
 def get_scrapers():
     import os, importlib, scrapers

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -112,69 +112,6 @@ def migrate_versions():
         except models.IntegrityError:
             pass
 
-'''
-class TagesschauArticle(Article):
-    SUFFIX = ''
-
-    def _parse(self, html):
-        soup = bs4.BeautifulSoup(html)
-
-        # extract the important text of the article into self.document #
-        # select the one article
-        article = soup.select('div.article')[0]
-        # removing comments
-        for x in self.descendants(article):
-            if isinstance(x, bs4.Comment):
-                x.extract()
-        # removing elements which don't provide content
-        for selector in ('.inv .teaserImg #seitenanfang .spacer .clearMe '+
-            '.boxMoreLinks .metaBlock .weltatlas .fPlayer .zitatBox .flashaudio').split(' '):
-            for x in article.select(selector):
-                x.extract()
-        # put hrefs into text form cause hrefs are important content
-        for x in article.select('a'):
-            x.append(" ["+x.get('href','')+"]")
-        # ensure proper formating for later use of get_text()
-        for x in article.select('li'):
-            x.append("\n")
-        for tag in 'p h1 h2 h3 h4 h5 ul div'.split(' '):
-            for x in article.select(tag):
-                x.append("\n\n")
-        # strip multiple newlines away
-        import re
-        article = re.subn('\n\n+', '\n\n', article.get_text())[0]
-        # important text is now extracted into self.document
-        self.document = article
-
-        self.title = soup.find('h1').get_text()
-
-        # a by-line is not always there, but when it is, it is em-tag and
-        # begins with the word 'Von'
-        byline = soup.find('em')
-        if byline:
-            byline = byline.get_text()
-            if 'Von ' not in byline: byline = None
-        if not byline: byline = "nicht genannt"
-        self.byline = byline
-
-        # TODO self.date is unused, isn't it? but i still fill it here
-        date = soup.select("div.standDatum")
-        self.date = date and date[0].get_text() or ''
-
-    # XXX a bug in bs4 that tag.descendants isnt working when .extract is called??
-    # TODO investigate and report
-    @staticmethod
-    def descendants(tag):
-        x = tag.next_element
-        while x:
-            next = x.next_element or x.parent and x.parent != tag and x.parent.next_sibling
-            yield x
-            x = next
-
-    def __unicode__(self):
-        return self.document
-'''
-
 #feeders = [
 
 #           ]
@@ -192,7 +129,7 @@ class TagesschauArticle(Article):
 domain_to_class = {}
 url_fetchers = []
 # checked with 'in scraper.fetcher_url', simple and stupid
-urls_to_fetch = 'cnn nyt politico bbc'.split(' ')
+urls_to_fetch = 'tagesschau'.split(' ')
 
 def get_scrapers():
     import os, importlib, scrapers

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -112,19 +112,6 @@ def migrate_versions():
         except models.IntegrityError:
             pass
 
-#feeders = [
-
-#           ]
-
-#DomainNameToClass = {'www.nytimes.com': Article,
-#                     'opinionator.blogs.nytimes.com': BlogArticle,
-#                     'krugman.blogs.nytimes.com': BlogArticle,
-#                     'edition.cnn.com': CNNArticle,
-#                     'www.politico.com': PoliticoArticle,
-#                     'www.bbc.co.uk': BBCArticle,
-#                     'www.tagesschau.de': TagesschauArticle,
-#                     }
-
 ###
 domain_to_class = {}
 url_fetchers = []

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -113,21 +113,6 @@ def migrate_versions():
             pass
 
 '''
-# NYT blogs
-# currently broken
-class BlogArticle(Article):
-    SUFFIX = '?pagemode=print'
-
-
-    def _parse(self, html):
-        div_id = url_to_filename(self.url).split('.')
-        soup = BeautifulSoup(html, convertEntities=BeautifulSoup.HTML_ENTITIES)
-        self.document = soup.find('div', attrs={'id':div_id})
-
-    def __unicode__(self):
-        return strip_whitespace(self.document.getText())
-
-
 class TagesschauArticle(Article):
     SUFFIX = ''
 

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -235,7 +235,7 @@ def update_article(article):
         parser = get_scraper(article.url)
     except KeyError:
         print 'no scraper'
-        print >> sys.stderr, 'unable to parse domain, skipping'
+        print >> sys.stderr, 'no scraper for', article.url
         return
 
     try:

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -62,8 +62,14 @@ scanned them recently, unless --all is passed.
             migrate_versions()
         else:
             print "load scrapers"
-            to_fetch = sum([x.split(' ') for x in options['fetch']], [])
-            print "fetch", ", ".join(to_fetch)
+            to_fetch = options['fetch']
+            if not to_fetch:
+                to_fetch = ['']
+                print "fetch all"
+            else:
+                to_fetch = [x.split(' ') for x in to_fetch]
+                to_fetch = set(filter(bool, sum(to_fetch, [])))
+                print "fetch", ", ".join(to_fetch)
             load_scrapers(to_fetch)
             print "update articles"
             update_articles()
@@ -136,7 +142,7 @@ def load_scrapers(to_fetch):
     for scraper in scrapers:
         domain_to_class[scraper.domain] = scraper
         ###
-        if any(pattern in scraper.domain for pattern in to_fetch):
+        if any(p in scraper.domain for p in to_fetch):
             url_fetchers.append(scraper.fetch_urls)
 
 def get_scrapers():

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -264,6 +264,8 @@ class TagesschauArticle(Article):
 ###
 domain_to_class = {}
 url_fetchers = []
+# checked with 'in scraper.fetcher_url', simple and stupid
+urls_to_fetch = ['cnn', 'nyt'] 
 
 def get_scrapers():
     import os, importlib, scrapers
@@ -279,7 +281,8 @@ def get_scrapers():
         and issubclass(article, scrapers.Article))
     for scraper in scrapers:
         domain_to_class[scraper.domain] = scraper
-        url_fetchers.append(scraper.fetch_urls)
+        if any(pattern in scraper.fetcher_url for pattern in urls_to_fetch):
+            url_fetchers.append(scraper.fetch_urls)
 
 get_scrapers()
 

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -113,31 +113,6 @@ def migrate_versions():
             pass
 
 '''
-class BBCArticle(Article):
-    SUFFIX = '?print=true'
-
-    def _parse(self, html):
-        print 'got html'
-        soup = BeautifulSoup(html, convertEntities=BeautifulSoup.HTML_ENTITIES,
-                             fromEncoding='utf-8')
-        print 'parsed'
-
-        self.meta = soup.findAll('meta')
-        self.title = soup.find('h1', 'story-header').getText()
-        self.byline = ''
-
-        div = soup.find('div', 'story-body')
-        self.body = '\n'+'\n\n'.join([x.getText() for x in div.childGenerator() if
-                                 isinstance(x, Tag) and x.name == 'p'])
-
-        self.date = soup.find('span', 'date').getText()
-
-    def __unicode__(self):
-        return strip_whitespace(u'\n'.join((self.date, self.title, self.byline,
-                                            self.body,)))
-
-
-
 # NYT blogs
 # currently broken
 class BlogArticle(Article):
@@ -216,8 +191,7 @@ class TagesschauArticle(Article):
 '''
 
 #feeders = [
-#           ('http://www.bbc.co.uk/news/',
-#            lambda url: 'www.bbc.co.uk/news' in url),
+
 #           ]
 
 #DomainNameToClass = {'www.nytimes.com': Article,
@@ -233,7 +207,7 @@ class TagesschauArticle(Article):
 domain_to_class = {}
 url_fetchers = []
 # checked with 'in scraper.fetcher_url', simple and stupid
-urls_to_fetch = 'cnn nyt politico'.split(' ')
+urls_to_fetch = 'cnn nyt politico bbc'.split(' ')
 
 def get_scrapers():
     import os, importlib, scrapers

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -9,7 +9,6 @@ from frontend import models
 import re
 from datetime import datetime, timedelta
 import traceback
-import sqlalchemy
 
 import diff_match_patch
 

--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -131,53 +131,7 @@ def get_all_article_urls():
         ans = ans.union(map(canonicalize_url, urls))
     return ans
 
-#Parser for NYT articles
-#also used as a base class for other parsers; probably should be split
-class Article(object):
-    url = None
-    title = None
-    date = None
-    body = None
-    real_article = True
-    meta = []
-    SUFFIX = '?pagewanted=all'
-
-    def __init__(self, url):
-        self.url = url
-        self.html = grab_url(url + self.SUFFIX)
-        open('/tmp/moo', 'w').write(self.html)
-        open('/tmp/moo3', 'w').write(url+self.SUFFIX)
-        self._parse(self.html)
-
-    def _parse(self, html):
-        soup = BeautifulSoup(html, convertEntities=BeautifulSoup.HTML_ENTITIES)
-        self.meta = soup.findAll('meta')
-        self.seo_title = soup.find('meta', attrs={'name':'hdl'}).get('content')
-        tmp = soup.find('meta', attrs={'name':'hdl_p'})
-        if tmp and tmp.get('content'):
-            self.title = tmp.get('content')
-        else:
-            self.title = self.seo_title
-        self.date = soup.find('meta', attrs={'name':'dat'}).get('content')
-        self.byline = soup.find('meta', attrs={'name':'byl'}).get('content')
-        p_tags = soup.findAll('p', attrs={'itemprop':'articleBody'})
-        self.body = '\n'.join([p.getText() for p in p_tags])
-        authorids = soup.find('div', attrs={'class':'authorIdentification'})
-        self.authorid = authorids.getText() if authorids else ''
-
-        self.top_correction = '\n'.join(x.getText() for x in
-                                   soup.findAll('nyt_correction_top')) or '\n'
-        self.bottom_correction = '\n'.join(x.getText() for x in
-                                   soup.findAll('nyt_correction_bottom')) or '\n'
-
-    def __unicode__(self):
-        return strip_whitespace(u'\n'.join((self.date, self.title, self.byline,
-                                            self.top_correction, self.body,
-                                            self.authorid,
-                                            self.bottom_correction,)))
-
-
-
+'''
 class PoliticoArticle(Article):
     SUFFIX = ''
 
@@ -307,11 +261,11 @@ class TagesschauArticle(Article):
 
     def __unicode__(self):
         return self.document
-
+'''
 
 feeders = [
-#            ('http://www.nytimes.com/',
-#            lambda url: 'www.nytimes.com/201' in url),
+           ('http://www.nytimes.com/',
+            lambda url: 'www.nytimes.com/201' in url),
            ('http://edition.cnn.com/',
             lambda url: 'edition.cnn.com/201' in url),
 #           ('http://www.politico.com/',

--- a/website/frontend/migrations/0002_auto__add_fields_chars_added_removed.py
+++ b/website/frontend/migrations/0002_auto__add_fields_chars_added_removed.py
@@ -7,15 +7,13 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
-        # Adding field 'Version.diff_json'
-        db.add_column('version', 'diff_json', self.gf('django.db.models.fields.CharField')(max_length=255, null=True), keep_default=False)
-
+        db.add_column('version', 'chars_added',
+            self.gf('django.db.models.fields.IntegerField')(null=True))
+        db.add_column('version', 'chars_removed',
+            self.gf('django.db.models.fields.IntegerField')(null=True))
 
     def backwards(self, orm):
-        
-        # Deleting field 'Version.diff_json'
-        db.delete_column('version', 'diff_json')
+        db.delete_column('version', 'chars_added', 'chars_removed')
 
 
     models = {
@@ -42,6 +40,8 @@ class Migration(SchemaMigration):
             'boring': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'byline': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'chars_added'  : ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'chars_removed': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
             'diff_json': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),

--- a/website/frontend/models.py
+++ b/website/frontend/models.py
@@ -21,6 +21,7 @@ PublicationDict = {'www.nytimes.com': 'NYT',
                    'edition.cnn.com': 'CNN',
                    'www.bbc.co.uk': 'BBC',
                    'www.politico.com': 'Politico',
+                   'www.tagesschau.de': 'Tagesschau',
                    }
 
 ancient = datetime(1901, 1, 1)
@@ -70,7 +71,8 @@ class Version(models.Model):
     byline = models.CharField(max_length=255,blank=False)
     date = models.DateTimeField(blank=False)
     boring = models.BooleanField(blank=False, default=False)
-    diff_json = models.CharField(max_length=255, null=True)
+    chars_added = models.IntegerField()
+    chars_removed = models.IntegerField()
 
     def text(self):
         try:
@@ -79,17 +81,6 @@ class Version(models.Model):
                                            cwd=GIT_DIR)
         except subprocess.CalledProcessError as e:
             return None
-
-    def get_diff_info(self):
-        if self.diff_json is None:
-            return {}
-        return json.loads(self.diff_json)
-    def set_diff_info(self, val=None):
-        if val is None:
-            self.diff_json = None
-        else:
-            self.diff_json = json.dumps(val)
-    diff_info = property(get_diff_info, set_diff_info)
 
 
 class Upvote(models.Model):

--- a/website/frontend/views.py
+++ b/website/frontend/views.py
@@ -63,7 +63,7 @@ def get_articles(source=None, distance=0):
     return articles
 
 
-SOURCES = 'nytimes.com cnn.com politico.com bbc.co.uk'.split() + ['']
+SOURCES = 'nytimes.com cnn.com politico.com bbc.co.uk tagesschau.de'.split() + ['']
 
 def browse(request, source=''):
     if source not in SOURCES:

--- a/website/scrapers/__init__.py
+++ b/website/scrapers/__init__.py
@@ -5,10 +5,29 @@ DATE_FORMAT = '%B %d, %Y at %l:%M%P EDT'
 class Article(object):
     SUFFIX = ''
     domain = ''
+    fetcher_url = ''
+    article_url_filter = lambda url: True
 
     def __init__(self, url):
         self.url = url
         self.real_article = True
         self.html = grab_url(url + self.SUFFIX)
         self._parse(self.html)
+        
+    @classmethod
+    def fetch_urls(self):
+        return find_article_urls(self.fetcher_url, self.article_url_filter)
+
+#Article urls for a single website
+from BeautifulSoup import BeautifulSoup
+def find_article_urls(feeder_url, filter_article, SoupVersion=BeautifulSoup):
+    html = grab_url(feeder_url)
+    soup = SoupVersion(html)
+
+    # "or ''" to make None into str
+    urls = [a.get('href') or '' for a in soup.findAll('a')]
+
+    domain = '/'.join(feeder_url.split('/')[:3])
+    urls = [url if '://' in url else domain + url for url in urls]
+    return [url for url in urls if filter_article(url)]
 

--- a/website/scrapers/__init__.py
+++ b/website/scrapers/__init__.py
@@ -1,0 +1,14 @@
+from frontend.management.commands._utils import *
+
+DATE_FORMAT = '%B %d, %Y at %l:%M%P EDT'
+
+class Article(object):
+    SUFFIX = ''
+    domain = ''
+
+    def __init__(self, url):
+        self.url = url
+        self.real_article = True
+        self.html = grab_url(url + self.SUFFIX)
+        self._parse(self.html)
+

--- a/website/scrapers/bbc.py
+++ b/website/scrapers/bbc.py
@@ -1,0 +1,30 @@
+from . import *
+from BeautifulSoup import BeautifulSoup, Tag
+
+class BBCArticle(Article):
+    SUFFIX = '?print=true'
+    domain = 'www.bbc.co.uk'
+    fetcher_url = 'http://www.bbc.co.uk/news/'
+    @staticmethod
+    def article_url_filter(url): return 'www.bbc.co.uk/news' in url
+
+    def _parse(self, html):
+        print 'got html'
+        soup = BeautifulSoup(html, convertEntities=BeautifulSoup.HTML_ENTITIES,
+                             fromEncoding='utf-8')
+        print 'parsed'
+
+        self.meta = soup.findAll('meta')
+        self.title = soup.find('h1', 'story-header').getText()
+        self.byline = ''
+
+        div = soup.find('div', 'story-body')
+        self.body = '\n'+'\n\n'.join([x.getText() for x in div.childGenerator() if
+                                 isinstance(x, Tag) and x.name == 'p'])
+
+        self.date = soup.find('span', 'date').getText()
+
+    def __unicode__(self):
+        return strip_whitespace(u'\n'.join((self.date, self.title, self.byline,
+                                            self.body,)))
+

--- a/website/scrapers/cnn.py
+++ b/website/scrapers/cnn.py
@@ -1,0 +1,40 @@
+from . import *
+
+class CNNArticle(Article):
+    SUFFIX = ''
+    domain = 'edition.cnn.com'
+
+    def _parse(self, html):
+        from BeautifulSoup import BeautifulSoup
+        from datetime import datetime, timedelta
+        import re
+        
+        print 'got html'
+        soup = BeautifulSoup(html, convertEntities=BeautifulSoup.HTML_ENTITIES,
+                             fromEncoding='utf-8')
+        print 'parsed'
+        p_tags = soup.findAll('p', attrs={'class':re.compile(r'\bcnn_storypgraphtxt\b')})
+        if not p_tags:
+            self.real_article = False
+            return
+
+        self.meta = soup.findAll('meta')
+        self.title = soup.find('meta', attrs={'itemprop':'headline'}).get('content')
+        datestr = soup.find('meta', attrs={'itemprop':'dateModified'}).get('content')
+        date = datetime.strptime(datestr, '%Y-%m-%dT%H:%M:%SZ') - timedelta(hours=4)
+        self.date = date.strftime(DATE_FORMAT)
+        self.byline = soup.find('meta', attrs={'itemprop':'author'}).get('content')
+        lede = p_tags[0].previousSibling.previousSibling
+
+        editornotes = soup.findAll('p', attrs={'class':'cnnEditorialNote'})
+        contributors = soup.findAll('p', attrs={'class':'cnn_strycbftrtxt'})
+        
+
+        self.body = '\n'+'\n\n'.join([p.getText() for p in
+                                      editornotes + [lede] + p_tags + contributors])
+        authorids = soup.find('div', attrs={'class':'authorIdentification'})
+
+    def __unicode__(self):
+        return strip_whitespace(u'\n'.join((self.date, self.title, self.byline,
+                                            self.body,)))
+

--- a/website/scrapers/cnn.py
+++ b/website/scrapers/cnn.py
@@ -3,6 +3,9 @@ from . import *
 class CNNArticle(Article):
     SUFFIX = ''
     domain = 'edition.cnn.com'
+    fetcher_url = 'http://edition.cnn.com/'
+    @staticmethod
+    def article_url_filter(url): return 'edition.cnn.com/201' in url
 
     def _parse(self, html):
         from BeautifulSoup import BeautifulSoup

--- a/website/scrapers/nyt.py
+++ b/website/scrapers/nyt.py
@@ -1,0 +1,35 @@
+from . import *
+
+# Parser for NYT articles
+class NytArticle(Article):
+    SUFFIX = '?pagewanted=all'
+    domain = 'www.nytimes.com'
+
+    def _parse(self, html):
+        from BeautifulSoup import BeautifulSoup
+    
+        soup = BeautifulSoup(html, convertEntities=BeautifulSoup.HTML_ENTITIES)
+        self.meta = soup.findAll('meta')
+        self.seo_title = soup.find('meta', attrs={'name':'hdl'}).get('content')
+        tmp = soup.find('meta', attrs={'name':'hdl_p'})
+        if tmp and tmp.get('content'):
+            self.title = tmp.get('content')
+        else:
+            self.title = self.seo_title
+        self.date = soup.find('meta', attrs={'name':'dat'}).get('content')
+        self.byline = soup.find('meta', attrs={'name':'byl'}).get('content')
+        p_tags = soup.findAll('p', attrs={'itemprop':'articleBody'})
+        self.body = '\n'.join([p.getText() for p in p_tags])
+        authorids = soup.find('div', attrs={'class':'authorIdentification'})
+        self.authorid = authorids.getText() if authorids else ''
+
+        self.top_correction = '\n'.join(x.getText() for x in
+                                   soup.findAll('nyt_correction_top')) or '\n'
+        self.bottom_correction = '\n'.join(x.getText() for x in
+                                   soup.findAll('nyt_correction_bottom')) or '\n'
+
+    def __unicode__(self):
+        return strip_whitespace(u'\n'.join((self.date, self.title, self.byline,
+                                            self.top_correction, self.body,
+                                            self.authorid,
+                                            self.bottom_correction,)))

--- a/website/scrapers/nyt.py
+++ b/website/scrapers/nyt.py
@@ -4,6 +4,9 @@ from . import *
 class NytArticle(Article):
     SUFFIX = '?pagewanted=all'
     domain = 'www.nytimes.com'
+    fetcher_url = 'http://www.nytimes.com/'
+    @staticmethod
+    def article_url_filter(url): return 'www.nytimes.com/201' in url
 
     def _parse(self, html):
         from BeautifulSoup import BeautifulSoup

--- a/website/scrapers/politico.py
+++ b/website/scrapers/politico.py
@@ -1,0 +1,35 @@
+from . import *
+import bs4
+
+class PoliticoArticle(Article):
+    domain = 'www.politico.com'
+    fetcher_url = 'http://www.politico.com/'
+    @staticmethod
+    def article_url_filter(url): return 'www.politico.com/news/stories' in url
+    find_article_urls_soup = bs4.BeautifulSoup
+
+    def _parse(self, html):
+        soup = bs4.BeautifulSoup(html)
+        print_link = soup.findAll('a', text='Print')[0].get('href')
+        html2 = grab_url(print_link)
+        # Now we have to switch back to bs3.  Hilarious.
+        # and the labeled encoding is wrong, so force utf-8.
+        soup = BeautifulSoup(html2, convertEntities=BeautifulSoup.HTML_ENTITIES,
+                             fromEncoding='utf-8')
+
+        self.meta = soup.findAll('meta')
+        p_tags = soup.findAll('p')[1:]
+
+        self.title = soup.find('strong').getText()
+        entity = soup.find('span', attrs={'class':'author'})
+        children = list(entity.childGenerator())
+        self.byline = 'By ' + children[1].getText()
+        datestr = children[-1].strip()
+        self.date = datestr
+
+        self.body = '\n'+'\n\n'.join([p.getText() for p in p_tags])
+
+    def __unicode__(self):
+        return strip_whitespace(u'\n'.join((self.date, self.title, self.byline,
+                                            self.body,)))
+

--- a/website/scrapers/tagesschau.py
+++ b/website/scrapers/tagesschau.py
@@ -10,7 +10,10 @@ class TagesschauArticle(Article):
         ''' Article urls for a single website. '''
         import feedparser
         feed = feedparser.parse(self.fetcher_url)
-        return [e.link for e in feed.entries]
+        no_article = ['www.tagesschau.de/multimedia/bilder/']
+        urls = [e.link for e in feed.entries
+                if not any(no in e.link for no in no_article)]
+        return urls
 
 
     def _parse(self, html):
@@ -19,7 +22,12 @@ class TagesschauArticle(Article):
 
         # extract the important text of the article into self.document #
         # select the one article
-        article = soup.select('div.article')[0]
+        article = soup.select('div.article')
+        # this
+        if not article:
+            self.real_article = False
+            return
+        article = article[0]
         # removing comments
         for x in self.descendants(article):
             if isinstance(x, bs4.Comment):

--- a/website/scrapers/tagesschau.py
+++ b/website/scrapers/tagesschau.py
@@ -1,0 +1,74 @@
+from . import *
+
+class TagesschauArticle(Article):
+    SUFFIX = ''
+    domain = 'www.tagesschau.de'
+    fetcher_url = 'http://www.tagesschau.de/newsticker.rdf'
+
+    @classmethod
+    def fetch_urls(self):
+        ''' Article urls for a single website. '''
+        import feedparser
+        feed = feedparser.parse(self.fetcher_url)
+        return [e.link for e in feed.entries]
+
+
+    def _parse(self, html):
+        import bs4
+        soup = bs4.BeautifulSoup(html)
+
+        # extract the important text of the article into self.document #
+        # select the one article
+        article = soup.select('div.article')[0]
+        # removing comments
+        for x in self.descendants(article):
+            if isinstance(x, bs4.Comment):
+                x.extract()
+        # removing elements which don't provide content
+        for selector in ('.inv .teaserImg #seitenanfang .spacer .clearMe '+
+            '.boxMoreLinks .metaBlock .weltatlas .fPlayer .zitatBox .flashaudio').split(' '):
+            for x in article.select(selector):
+                x.extract()
+        # put hrefs into text form cause hrefs are important content
+        for x in article.select('a'):
+            x.append(" ["+x.get('href','')+"]")
+        # ensure proper formating for later use of get_text()
+        for x in article.select('li'):
+            x.append("\n")
+        for tag in 'p h1 h2 h3 h4 h5 ul div'.split(' '):
+            for x in article.select(tag):
+                x.append("\n\n")
+        # strip multiple newlines away
+        import re
+        article = re.subn('\n\n+', '\n\n', article.get_text())[0]
+        # important text is now extracted into self.document
+        self.document = article
+
+        self.title = soup.find('h1').get_text()
+
+        # a by-line is not always there, but when it is, it is em-tag and
+        # begins with the word 'Von'
+        byline = soup.find('em')
+        if byline:
+            byline = byline.get_text()
+            if 'Von ' not in byline: byline = None
+        if not byline: byline = "nicht genannt"
+        self.byline = byline
+
+        # TODO self.date is unused, isn't it? but i still fill it here
+        date = soup.select("div.standDatum")
+        self.date = date and date[0].get_text() or ''
+
+    # XXX a bug in bs4 that tag.descendants isnt working when .extract is called??
+    # TODO investigate and report
+    @staticmethod
+    def descendants(tag):
+        x = tag.next_element
+        while x:
+            next = x.next_element or x.parent and x.parent != tag and x.parent.next_sibling
+            yield x
+            x = next
+
+    def __unicode__(self):
+        return self.document
+

--- a/website/settings_main.py
+++ b/website/settings_main.py
@@ -96,5 +96,6 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
+    'south',
     'frontend',
 )


### PR DESCRIPTION
In this branch I move the *Article classes into a `website/scrapers/` directory. Each in one file. Alongside the domain and url to fetch from. I also split `NytArticle` off of the base `Article` class.

`scraper.py` has now another option `--fetch`, which I used to quickly test different scrapers without to run all of them. It matches them vaguely enough such that I can say `--fetch cnn` or `--fetch "tagess bbc" --fetch cnn`.

To load `Article` classes all modules in the scrapers directory are loaded and their content is filtered for `isinstance(article, scrapers.Article)`. The mapping between domain and classes and the urls to fetch from are filled with the data written in each `Article` class, filtered by the arguments to `--fetch`. Works :-)

Something which is in this branch but does not belong here: the printed output is a little bit more verbose for `update_articles` and more "oneliner oriented" for `update_versions`. Hope you like it.

I also moved the utility functions and the monkey patches in `scraper.py` to their own files next to it, so the file is not so crowded with … stuff. In which folder they really belong, I don't know. Maybe right there where they are. There are some wildcard imports, which need to be looked at. As I moved code I also noticed (again) that putting imports near the places where they are needed, is faster to handle. The usual downside is, that missing module dependencies are only noticed late at runtime… well.

I didn't look into the web stuff to add scraper domains there too.

So TODO for this branch is still:
- looking at wildcard imports and change them to something less hurting
- where to put `_monkeypatch.py` and `_utils.py`
- configurable, more automatic web frontend stuff, when a scraper is added/removed
- say what you think :-)
