### PR TITLE
Fix bug with embedded videos in BBC stories

### DIFF
--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -363,6 +363,9 @@ class BBCArticle(Article):
         self.byline = ''
 
         div = soup.find('div', 'story-body')
+        if not div:
+            # Hack for video articles
+            div = soup.find('div', 'emp-decription') # Not a typo
         self.body = '\n'+'\n\n'.join([x.getText() for x in div.childGenerator() if
                                  isinstance(x, Tag) and x.name == 'p'])
 


### PR DESCRIPTION
The scraper was having trouble with BBC articles with embedded videos, because they don't have a "story-body" div element. I added a bit of code to try set the div element to the one holding the video description if there wasn't a "story-body" div, so the scraper can find the text in these cases.

The descriptions are usually short and content-lite, but I bet they could be interesting to track, too. For example, here's something from today:

![Gunned down](https://s3.amazonaws.com/zthomae-project-pics/gunneddown.png)
