### PR TITLE
Update requirements.txt with latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 BeautifulSoup==3.2.1
 Django==1.5.1
+South==0.7.6
 beautifulsoup4==4.1.3
 simplejson==3.1.2


### PR DESCRIPTION
`requirements.txt` should explicitly mention dependency versions.
Latest and greatest seem to work just fine.

Also, south was missing.
