### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Do the initial setup above.  Then to start the webserver for testing:
 
     python website/manage.py runserver
 
-and visit `http://localhost:8000/`
+and visit [http://localhost:8000/](http://localhost:8000/)
 
 
 Running the scraper
@@ -68,7 +68,7 @@ some websites are parsed correctly in only one version.
 
 Then run
 
-   python website/manage.py scraper
+    python website/manage.py scraper
 
 This will populate the articles repository with a list of current news
 articles.  This is a snapshot at a single time, so the website will


### PR DESCRIPTION
Adding the MD extension (last night) caused some things to display differently than they should have.

This PR fixes that. 

Note: I removed leading $ before bash lines because it's easier to copy and paste if they're not there.
