### PR TITLE
Backend/parsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /articles
 
 *~

--- a/parsers/zeit.py
+++ b/parsers/zeit.py
@@ -1,0 +1,34 @@
+from baseparser import BaseParser
+from BeautifulSoup import BeautifulSoup, Tag
+
+
+class ZeitParser(BaseParser):
+    SUFFIX = '?print=true'
+    domains = ['www.zeit.de']
+
+    feeder_pat   = '^http://www.zeit.de/news/\d'
+    feeder_pages = ['http://www.zeit.de/news/index/']
+
+    def _parse(self, html):
+        soup = BeautifulSoup(html, convertEntities=BeautifulSoup.HTML_ENTITIES,
+                             fromEncoding='utf-8')
+
+        self.meta = soup.findAll('meta')
+        elt = soup.find('span', 'title')
+	elTopic = soup.find('span', 'supertitle')
+        if elt is None:
+            self.real_article = False
+            return
+        self.title = elt.getText()
+        self.byline = ''
+        self.date = soup.find('span', 'articlemeta-datetime').getText()
+
+        div = soup.find('div', 'article-body')
+        if div is None:
+            # Hack for video articles
+            div = soup.find('div', 'emp-decription')
+        if div is None:
+            self.real_article = False
+            return
+        self.body = '\n'+'\n\n'.join([x.getText() for x in div.childGenerator()
+                                      if isinstance(x, Tag) and x.name == 'p'])

--- a/website/manage.py
+++ b/website/manage.py
@@ -11,7 +11,7 @@ except OSError:
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "website.settings")
-    sys.path.append(os.path.dirname(os.getcwd()))
+    sys.path.append((os.getcwd()))
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
- Added Zeit.de-Parser in parsers/zeit.py
- Enhanced the baseparser.py to be able to just collect links from certain parts(divs) of the newspage instead of the whole page, as most pages do have pages with URLs to the article pages that do not need to be tracked.