### PR TITLE
Fixed issues with https:// and disabled the functionality to browse old days' data 

### DIFF
--- a/website/frontend/management/commands/scraper.py
+++ b/website/frontend/management/commands/scraper.py
@@ -115,15 +115,6 @@ def mkdir_p(path):
 def canonicalize_url(url):
     return url.split('?')[0].split('#')[0].strip()
 
-def strip_prefix(string, prefix):
-    if string.startswith(prefix):
-        string = string[len(prefix):]
-    return string
-
-def url_to_filename(url):
-    return strip_prefix(url, 'http://').rstrip('/')
-
-
 class IndexLockError(OSError):
     pass
 
@@ -333,7 +324,7 @@ def update_article(article):
     t = datetime.now()
     logger.debug('Article parsed; trying to store')
     v, boring, diff_info = add_to_git_repo(to_store,
-                                           url_to_filename(article.url),
+                                           article.filename(),
                                            article)
     if v:
         logger.info('Modifying! new blob: %s', v)

--- a/website/frontend/models.py
+++ b/website/frontend/models.py
@@ -43,7 +43,14 @@ class Article(models.Model):
         return GIT_DIR + self.git_dir
 
     def filename(self):
-        return self.url[len('http://'):].rstrip('/')
+        ans = self.url.rstrip('/')
+        if ans.startswith('http://'):
+            return ans[len('http://'):]
+        elif ans.startswith('https://'):
+            # Terrible hack for backwards compatibility from when https was stored incorrectly,
+            # perpetuating the problem
+            return 'https:/' + ans[len('https://'):]
+        raise ValueError("Unknown file type '%s'" % self.url)
 
     def publication(self):
         return PublicationDict.get(self.url.split('/')[2])

--- a/website/frontend/templates/browse_base.html
+++ b/website/frontend/templates/browse_base.html
@@ -15,7 +15,9 @@
           </ul>
 
       <h1>Changed Articles {% block browse_fromline %}{% endblock browse_fromline %}</h1>
-      <p>Starting {{first_update|date:"F d, Y"}} (with occasional downtime)</p>
+      <!--<p>Starting {{first_update|date:"F d, Y"}} (with occasional
+      downtime)</p>-->
+	  <p>Changes observed today</p>
       <p>  
 
     <table class="table table-condensed"  style="width:100%">

--- a/website/frontend/views.py
+++ b/website/frontend/views.py
@@ -121,9 +121,15 @@ def browse(request, source=''):
     except ValueError:
         page = 1
 
+    # Temporarily disable browsing past the first page, since it was
+    # overloading the server.
+    if page != 1:
+        return HttpResponseRedirect(reverse(browse))
+
     first_update = get_first_update(source)
     num_pages = (datetime.datetime.now() - first_update).days + 1
     page_list=range(1, 1+num_pages)
+    page_list = []
 
     articles = get_articles(source=source, distance=page-1)
     return render_to_response('browse.html', {


### PR DESCRIPTION
    1) Remove ability to browse old days' data.
    This was causing load issues, and didn't have a good interface.
    We should make it more usable + cache the results.

    2) Fix how https:// urls are accessed.
    There was a bug where urls starting with https:// were stored in
    https://domain.com/blah by the parser, and accessed at
    /domain.com/blah by the website.
    Now the same function is used for both.  For backwards compatibility,
    this is domain.com/blah for http:// and https:/domain.com/blah for
    https://