### PR TITLE
Upgrade to Django 1.6 and add CONN_MAX_AGE: 60

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -1,0 +1,40 @@
+# This locust test script example will simulate a user
+# browsing the Locust documentation on http://docs.locust.io
+
+import random
+from locust import HttpLocust, TaskSet, task
+from pyquery import PyQuery
+
+
+class BrowseLinks(TaskSet):
+    def on_start(self):
+        # assume all users arrive at the index page
+        self.index_page()
+        self.urls_on_current_page = self.toc_urls
+
+    @task(10)
+    def index_page(self):
+        r = self.client.get("/browse/")
+        pq = PyQuery(r.content)
+        link_elements = pq("a")
+        self.toc_urls = [l.attrib["href"] for l in link_elements if 'href' in l.attrib]
+
+    @task(50)
+    def load_page(self):
+        url = random.choice(self.toc_urls)
+        r = self.client.get(url)
+        pq = PyQuery(r.content)
+        link_elements = pq("a")
+        self.urls_on_current_page = [l.attrib["href"] for l in link_elements if 'href' in l.attrib]
+
+
+class AwesomeUser(HttpLocust):
+    task_set = BrowseLinks
+    host = "http://127.0.0.1:8000"
+
+    # we assume someone who is browsing the Locust docs,
+    # generally has a quite long waiting time (between
+    # 20 and 600 seconds), since there's a bunch of text
+    # on each page
+    min_wait = 1 * 1000
+    max_wait = 5 * 1000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Django <= 1.5
+Django==1.6
 simplejson
 beautifulsoup4
 beautifulsoup
-South
+South==1.0.2
 html5lib
 python-dateutil==2.7.3
 pytest==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ html5lib
 python-dateutil==2.7.3
 pytest==3.5.1
 mock==2.0.0
+locustio==0.8.1
+pyquery==1.4.0
+mysqlclient==1.3.13

--- a/website/frontend/models.py
+++ b/website/frontend/models.py
@@ -133,9 +133,10 @@ def check_output(*popenargs, **kwargs):
     The stdout argument is not allowed as it is used internally.
     To capture standard error in the result, use stderr=STDOUT.
 
+    >>> import sys
     >>> check_output(["/bin/sh", "-c",
     ...               "ls -l non_existent_file ; exit 0"],
-    ...              stderr=STDOUT)
+    ...              stderr=sys.stdout)
     'ls: non_existent_file: No such file or directory\n'
     """
     from subprocess import PIPE, CalledProcessError, Popen

--- a/website/settings_main.py
+++ b/website/settings_main.py
@@ -25,6 +25,11 @@ DATABASES = {
         'NAME': 'newsdiffs+newsdiffs',
         'USER': 'newsdiffs',
         'PASSWORD': pwd,
+        # The lifetime of a database connection, in seconds. Use 0 to close
+        # database connections at the end of each request - Django's historical
+        # behavior - and None for unlimited persistent connections.
+        # https://docs.djangoproject.com/en/1.9/ref/settings/#conn-max-age
+        'CONN_MAX_AGE': 60,
         'OPTIONS': {
 # This doesn't seem to work.
 #            'read_default_file': '/mit/ecprice/.my.cnf',


### PR DESCRIPTION
There are only two substantive changes: upgrading Django to 1.6 so that we can add CONN_MAX_AGE: 60, which leaves DB connections open for re-use for 60s.  This should help a little with handling load.

The other changes are mostly related to load testing and taking notes on what I did for load testing so that someone can recreate later.