### PR TITLE
Fix BBC scraper heading and date

### DIFF
--- a/parsers/bbc.py
+++ b/parsers/bbc.py
@@ -14,13 +14,13 @@ class BBCParser(BaseParser):
                              fromEncoding='utf-8')
 
         self.meta = soup.findAll('meta')
-        elt = soup.find('h1', 'story-header')
+        elt = soup.find('h1', 'story-body__h1')
         if elt is None:
             self.real_article = False
             return
         self.title = elt.getText()
         self.byline = ''
-        self.date = soup.find('span', 'date').getText()
+        self.date = soup.find('div', 'date date--v2').get('data-datetime')
 
         div = soup.find('div', 'story-body')
         if div is None:


### PR DESCRIPTION
Tested this locally and seems to work correctly.

Worth noting that the files are spit out into one flat directory due to the BBCs URL structure (all articles come under /news/)

Also looks like story bodies for some AV articles is still not working.

To get it working locally I also had to follow this fix https://github.com/ecprice/newsdiffs/issues/25